### PR TITLE
Rebuild ledger as KidBank-style package

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,75 @@
-# Another-D-D-tool
+# Another D&D Tool
+
+This project mirrors the structure of the original [KidBank](https://github.com/IrishSpear/kidbank) app while focusing on tabletop parties instead of kids' allowances. It ships as a Python package with well-tested domain objects, a high-level service façade, and a lightweight CLI for persisting gold ledgers to disk.
+
+## Project structure
+
+```
+src/
+  dndbank/
+    __init__.py        # Public exports (DnDBank, models, exceptions)
+    account.py         # CharacterAccount domain logic
+    cli.py             # Argparse CLI for working with JSON ledgers
+    exceptions.py      # Error hierarchy
+    models.py          # Dataclasses and enums describing transactions
+    money.py           # Decimal helpers for gold piece arithmetic
+    service.py         # DnDBank façade coordinating accounts
+pytest.ini             # Configures pytest to discover src/ package
+tests/
+  test_account.py      # Unit tests for CharacterAccount behaviour
+  test_service.py      # Integration tests for the DnDBank façade
+```
+
+## Installation
+
+The package only depends on the Python standard library. Python 3.10 or newer is recommended to match the typing used throughout the project.
+
+Optionally create and activate a virtual environment, then install the project in editable mode for easier experimentation:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -e .
+```
+
+## Running the test suite
+
+Run the included tests (modelled after KidBank's coverage) with:
+
+```bash
+python -m pytest
+```
+
+## Using the CLI
+
+The CLI lives alongside the package and persists data in a JSON file (default `dnd_ledger.json`). Invoke it via the module entry point:
+
+```bash
+python -m dndbank.cli --help
+```
+
+### Create characters
+
+```bash
+python -m dndbank.cli create "Sir Galahad" --player "Alice" --gold 50
+python -m dndbank.cli create "Mira Quickstep" --player "Bob"
+```
+
+### Record treasure and expenses
+
+```bash
+python -m dndbank.cli earn "Sir Galahad" 250 --reason "Dragon hoard"
+python -m dndbank.cli spend "Mira Quickstep" 25 --reason "Thieves' guild dues"
+python -m dndbank.cli transfer "Sir Galahad" "Mira Quickstep" 50 --reason "Shared spoils"
+python -m dndbank.cli distribute 120 "Sir Galahad" "Mira Quickstep" --reason "Chest of coins"
+```
+
+### Check balances and history
+
+```bash
+python -m dndbank.cli status               # Show everyone
+python -m dndbank.cli status "Mira Quickstep"  # Show one character
+python -m dndbank.cli history "Mira Quickstep"
+```
+
+Because the ledger file is plain JSON you can commit it to version control or copy it between machines to keep a party's finances synchronised.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Another D&D Tool
 
-This project mirrors the structure of the original [KidBank](https://github.com/IrishSpear/kidbank) app while focusing on tabletop parties instead of kids' allowances. It ships as a Python package with well-tested domain objects, a high-level service façade, and a lightweight CLI for persisting gold ledgers to disk.
+This project mirrors the structure of the original [KidBank](https://github.com/IrishSpear/kidbank) app while focusing on tabletop parties instead of kids' allowances. It now ships with a Flask-powered web dashboard, well-tested domain objects, a high-level service façade, and a lightweight CLI for persisting gold ledgers to disk.
 
 ## Project structure
 
@@ -38,6 +38,39 @@ Run the included tests (modelled after KidBank's coverage) with:
 
 ```bash
 python -m pytest
+```
+
+## Running the web app
+
+Launch the KidBank-style dashboard with Flask (it stores the ledger JSON in the Flask instance folder by default):
+
+```bash
+flask --app dndbank.web --debug run
+```
+
+Alternatively run it directly via Python:
+
+```bash
+python -m dndbank.web
+```
+
+Once running, visit http://127.0.0.1:5000/ to manage characters, award loot, log expenses, split treasure, and transfer gold between party members. Flash messages mirror the KidBank UX by confirming successful actions or highlighting validation issues.
+
+To customise persistence, set `DND_BANK_SECRET_KEY` and/or override the ledger path:
+
+```bash
+export DND_BANK_SECRET_KEY="your-secret"
+export FLASK_APP=dndbank.web
+export FLASK_RUN_EXTRA_FILES=/path/to/dnd_ledger.json  # optional auto reload
+flask run --reload
+```
+
+You can also configure the JSON location when constructing the app yourself:
+
+```python
+from dndbank import create_app
+
+app = create_app({"LEDGER_PATH": "/path/to/ledger.json"})
 ```
 
 ## Using the CLI

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,9 @@ readme = "README.md"
 requires-python = ">=3.10"
 authors = [{ name = "Irish Spear" }]
 keywords = ["dnd", "ledger", "kidbank"]
+dependencies = [
+  "Flask>=2.3,<3",
+]
 classifiers = [
   "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3.10",
@@ -18,3 +21,6 @@ classifiers = [
 
 [tool.setuptools.packages.find]
 where = ["src"]
+
+[tool.setuptools.package-data]
+"dndbank" = ["templates/*.html", "static/*.css"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,20 @@
+[build-system]
+requires = ["setuptools>=65", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "dndbank"
+version = "0.1.0"
+description = "KidBank-inspired D&D treasury manager"
+readme = "README.md"
+requires-python = ">=3.10"
+authors = [{ name = "Irish Spear" }]
+keywords = ["dnd", "ledger", "kidbank"]
+classifiers = [
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.10",
+  "License :: OSI Approved :: MIT License",
+]
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+addopts = -q
+pythonpath = src

--- a/src/dndbank/__init__.py
+++ b/src/dndbank/__init__.py
@@ -8,6 +8,7 @@ from .exceptions import (
 )
 from .models import EventCategory, Transaction, TransactionType
 from .service import DnDBank
+from .web import create_app
 
 __all__ = [
     "CharacterAccount",
@@ -18,4 +19,5 @@ __all__ = [
     "InsufficientFundsError",
     "Transaction",
     "TransactionType",
+    "create_app",
 ]

--- a/src/dndbank/__init__.py
+++ b/src/dndbank/__init__.py
@@ -1,0 +1,21 @@
+"""DnDBank package mirroring the KidBank structure for tabletop parties."""
+
+from .account import CharacterAccount
+from .exceptions import (
+    CharacterAlreadyExistsError,
+    CharacterNotFoundError,
+    InsufficientFundsError,
+)
+from .models import EventCategory, Transaction, TransactionType
+from .service import DnDBank
+
+__all__ = [
+    "CharacterAccount",
+    "CharacterAlreadyExistsError",
+    "CharacterNotFoundError",
+    "DnDBank",
+    "EventCategory",
+    "InsufficientFundsError",
+    "Transaction",
+    "TransactionType",
+]

--- a/src/dndbank/account.py
+++ b/src/dndbank/account.py
@@ -1,0 +1,186 @@
+"""Character account logic for managing tabletop treasure."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from decimal import Decimal
+from typing import Mapping, Optional, Tuple
+
+from .exceptions import InsufficientFundsError
+from .models import EventCategory, Transaction, TransactionType
+from .money import AmountLike, require_positive, to_decimal
+
+
+class CharacterAccount:
+    """Represents an adventurer's personal hoard."""
+
+    __slots__ = ("name", "player", "_balance", "_transactions")
+
+    @classmethod
+    def from_serialized(cls, payload: Mapping[str, object]) -> "CharacterAccount":
+        """Rehydrate an account from a JSON-compatible payload."""
+
+        account = cls(
+            str(payload["name"]),
+            player=payload.get("player") or None,
+            starting_gold=0,
+        )
+        account._balance = to_decimal(payload.get("balance", 0))
+        account._transactions.clear()
+        for raw in payload.get("transactions", []):
+            account._transactions.append(
+                Transaction(
+                    amount=to_decimal(raw["amount"]),
+                    type=TransactionType(raw["type"]),
+                    description=str(raw["description"]),
+                    category=EventCategory(raw["category"]),
+                    timestamp=datetime.fromisoformat(raw["timestamp"]),
+                    metadata=dict(raw.get("metadata", {})),
+                )
+            )
+        return account
+
+    def __init__(
+        self,
+        name: str,
+        *,
+        player: str | None = None,
+        starting_gold: AmountLike = 0,
+    ) -> None:
+        self.name = name
+        self.player = player
+        starting_value = to_decimal(starting_gold)
+        require_positive(starting_value, allow_zero=True)
+        self._balance: Decimal = starting_value
+        self._transactions: list[Transaction] = []
+
+        if starting_value > Decimal("0"):
+            self._log_transaction(
+                starting_value,
+                TransactionType.ADJUSTMENT,
+                "Starting purse",
+                EventCategory.MANUAL,
+                {"source": "initial"},
+                timestamp=datetime.now(timezone.utc),
+            )
+
+    @property
+    def balance(self) -> Decimal:
+        return self._balance
+
+    @property
+    def transactions(self) -> Tuple[Transaction, ...]:
+        return tuple(self._transactions)
+
+    def earn(
+        self,
+        amount: AmountLike,
+        description: str = "Treasure haul",
+        *,
+        category: EventCategory | None = None,
+        metadata: Optional[Mapping[str, str]] = None,
+    ) -> Transaction:
+        value = to_decimal(amount)
+        require_positive(value)
+        self._balance += value
+        return self._log_transaction(
+            value,
+            TransactionType.EARN,
+            description,
+            category or EventCategory.LOOT,
+            metadata,
+        )
+
+    def spend(
+        self,
+        amount: AmountLike,
+        description: str = "Purchase",
+        *,
+        category: EventCategory | None = None,
+        metadata: Optional[Mapping[str, str]] = None,
+    ) -> Transaction:
+        value = to_decimal(amount)
+        require_positive(value)
+        self._ensure_sufficient(value)
+        self._balance -= value
+        return self._log_transaction(
+            value,
+            TransactionType.SPEND,
+            description,
+            category or EventCategory.PURCHASE,
+            metadata,
+        )
+
+    def transfer_to(
+        self,
+        other: "CharacterAccount",
+        amount: AmountLike,
+        description: str | None = None,
+        *,
+        metadata: Optional[Mapping[str, str]] = None,
+    ) -> tuple[Transaction, Transaction]:
+        value = to_decimal(amount)
+        require_positive(value)
+        self._ensure_sufficient(value)
+        self._balance -= value
+        other._balance += value
+
+        summary_out = description or f"Transfer to {other.name}"
+        summary_in = description or f"Transfer from {self.name}"
+        ts = datetime.now(timezone.utc)
+        outbound = self._log_transaction(
+            value,
+            TransactionType.TRANSFER_OUT,
+            summary_out,
+            EventCategory.MANUAL,
+            metadata,
+            timestamp=ts,
+        )
+        inbound = other._log_transaction(
+            value,
+            TransactionType.TRANSFER_IN,
+            summary_in,
+            EventCategory.MANUAL,
+            metadata,
+            timestamp=ts,
+        )
+        return outbound, inbound
+
+    def _ensure_sufficient(self, amount: Decimal) -> None:
+        if self._balance < amount:
+            raise InsufficientFundsError(
+                f"{self.name} lacks sufficient gold (needs {amount}, has {self._balance})."
+            )
+
+    def _log_transaction(
+        self,
+        amount: Decimal,
+        type_: TransactionType,
+        description: str,
+        category: EventCategory,
+        metadata: Optional[Mapping[str, str]] = None,
+        *,
+        timestamp: datetime | None = None,
+    ) -> Transaction:
+        record = Transaction(
+            amount=amount,
+            type=type_,
+            description=description,
+            category=category,
+            timestamp=timestamp or datetime.now(timezone.utc),
+            metadata=dict(metadata or {}),
+        )
+        self._transactions.append(record)
+        return record
+
+    def summary(self) -> str:
+        owner = f" (Player: {self.player})" if self.player else ""
+        return f"{self.name}{owner} — {self._balance} gp"
+
+    def to_serialized(self) -> dict[str, object]:
+        return {
+            "name": self.name,
+            "player": self.player,
+            "balance": str(self._balance),
+            "transactions": [entry.as_dict() for entry in self._transactions],
+        }

--- a/src/dndbank/cli.py
+++ b/src/dndbank/cli.py
@@ -1,0 +1,244 @@
+"""Command line interface mirroring the KidBank tooling layout."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Iterable
+
+from .exceptions import (
+    CharacterAlreadyExistsError,
+    CharacterNotFoundError,
+    InsufficientFundsError,
+)
+from .models import EventCategory, TransactionType
+from .money import format_gp
+from .service import DnDBank
+
+DEFAULT_LEDGER = Path("dnd_ledger.json")
+
+
+def load_bank(path: Path) -> DnDBank:
+    if not path.exists():
+        return DnDBank()
+    data = json.loads(path.read_text())
+    return DnDBank.from_serialized(data)
+
+
+def save_bank(path: Path, bank: DnDBank) -> None:
+    path.write_text(json.dumps(bank.to_serialized(), indent=2))
+
+
+def add_common_arguments(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--ledger",
+        type=Path,
+        default=DEFAULT_LEDGER,
+        help="Path to the persistent ledger file (default: ./dnd_ledger.json)",
+    )
+
+
+def cmd_create(args: argparse.Namespace) -> None:
+    bank = load_bank(args.ledger)
+    try:
+        bank.create_character(args.name, player=args.player, starting_gold=args.gold)
+    except CharacterAlreadyExistsError as exc:
+        raise SystemExit(str(exc))
+    save_bank(args.ledger, bank)
+    print(f"Created {args.name} with starting balance {format_gp(args.gold)}")
+
+
+def cmd_earn(args: argparse.Namespace) -> None:
+    bank = load_bank(args.ledger)
+    try:
+        txn = bank.earn_gold(
+            args.name,
+            args.amount,
+            description=args.reason,
+            category=EventCategory(args.category) if args.category else None,
+        )
+    except (CharacterNotFoundError, ValueError) as exc:
+        raise SystemExit(str(exc))
+    save_bank(args.ledger, bank)
+    print(
+        f"{args.name} earned {format_gp(txn.amount)} for {txn.description}. "
+        f"New balance: {format_gp(bank.get_character(args.name).balance)}"
+    )
+
+
+def cmd_spend(args: argparse.Namespace) -> None:
+    bank = load_bank(args.ledger)
+    try:
+        txn = bank.spend_gold(
+            args.name,
+            args.amount,
+            description=args.reason,
+            category=EventCategory(args.category) if args.category else None,
+        )
+    except (CharacterNotFoundError, ValueError, InsufficientFundsError) as exc:
+        raise SystemExit(str(exc))
+    save_bank(args.ledger, bank)
+    print(
+        f"{args.name} spent {format_gp(txn.amount)} on {txn.description}. "
+        f"New balance: {format_gp(bank.get_character(args.name).balance)}"
+    )
+
+
+def cmd_transfer(args: argparse.Namespace) -> None:
+    bank = load_bank(args.ledger)
+    try:
+        outgoing, incoming = bank.transfer_gold(
+            args.source,
+            args.target,
+            args.amount,
+            description=args.reason,
+        )
+    except (CharacterNotFoundError, ValueError, InsufficientFundsError) as exc:
+        raise SystemExit(str(exc))
+    save_bank(args.ledger, bank)
+    source_balance = bank.get_character(args.source).balance
+    target_balance = bank.get_character(args.target).balance
+    print(
+        f"Transferred {format_gp(outgoing.amount)} from {args.source} to {args.target}. "
+        f"Balances: {format_gp(source_balance)} / {format_gp(target_balance)}"
+    )
+
+
+def cmd_status(args: argparse.Namespace) -> None:
+    bank = load_bank(args.ledger)
+    if args.name:
+        try:
+            account = bank.get_character(args.name)
+        except CharacterNotFoundError as exc:
+            raise SystemExit(str(exc))
+        print(account.summary())
+        return
+
+    if not bank.list_characters():
+        print("No characters recorded. Use 'create' to add one.")
+        return
+
+    for name in bank.list_characters():
+        account = bank.get_character(name)
+        print(account.summary())
+
+
+def cmd_history(args: argparse.Namespace) -> None:
+    bank = load_bank(args.ledger)
+    try:
+        account = bank.get_character(args.name)
+    except CharacterNotFoundError as exc:
+        raise SystemExit(str(exc))
+
+    if not account.transactions:
+        print(f"No transactions recorded for {args.name}.")
+        return
+
+    for entry in account.transactions:
+        verb = {
+            TransactionType.EARN: "received",
+            TransactionType.TRANSFER_IN: "received",
+            TransactionType.SPEND: "spent",
+            TransactionType.TRANSFER_OUT: "transferred",
+            TransactionType.ADJUSTMENT: "adjusted",
+        }[entry.type]
+        amount = format_gp(entry.amount)
+        print(
+            f"[{entry.timestamp.isoformat()}] {args.name} {verb} {amount}"
+            f" for {entry.description} ({entry.category.value})"
+        )
+
+
+def cmd_distribute(args: argparse.Namespace) -> None:
+    bank = load_bank(args.ledger)
+    try:
+        txns = bank.distribute_loot(
+            args.characters,
+            total_amount=args.amount,
+            description=args.reason,
+            category=EventCategory(args.category) if args.category else EventCategory.LOOT,
+        )
+    except (CharacterNotFoundError, ValueError) as exc:
+        raise SystemExit(str(exc))
+    save_bank(args.ledger, bank)
+    amount = format_gp(args.amount)
+    names = ", ".join(args.characters)
+    print(f"Split {amount} across {names} ({len(txns)} shares recorded)")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Manage D&D treasure with a KidBank-style toolkit.",
+    )
+    add_common_arguments(parser)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    create = subparsers.add_parser("create", help="Register a new adventurer")
+    create.add_argument("name")
+    create.add_argument("--player", help="Player owning the character")
+    create.add_argument("--gold", type=float, default=0, help="Starting gold pieces")
+    create.set_defaults(func=cmd_create)
+
+    earn = subparsers.add_parser("earn", help="Record loot for an adventurer")
+    earn.add_argument("name")
+    earn.add_argument("amount", type=float)
+    earn.add_argument("--reason", default="Treasure haul")
+    earn.add_argument(
+        "--category",
+        choices=[c.value for c in EventCategory],
+        help="Optional event category",
+    )
+    earn.set_defaults(func=cmd_earn)
+
+    spend = subparsers.add_parser("spend", help="Log purchases or expenses")
+    spend.add_argument("name")
+    spend.add_argument("amount", type=float)
+    spend.add_argument("--reason", default="Purchase")
+    spend.add_argument(
+        "--category",
+        choices=[c.value for c in EventCategory],
+        help="Optional event category",
+    )
+    spend.set_defaults(func=cmd_spend)
+
+    transfer = subparsers.add_parser("transfer", help="Move gold between characters")
+    transfer.add_argument("source")
+    transfer.add_argument("target")
+    transfer.add_argument("amount", type=float)
+    transfer.add_argument("--reason", help="Narrative for the transfer")
+    transfer.set_defaults(func=cmd_transfer)
+
+    status = subparsers.add_parser("status", help="View balances")
+    status.add_argument("name", nargs="?")
+    status.set_defaults(func=cmd_status)
+
+    history = subparsers.add_parser("history", help="Inspect a ledger history")
+    history.add_argument("name")
+    history.set_defaults(func=cmd_history)
+
+    distribute = subparsers.add_parser(
+        "distribute",
+        help="Evenly distribute loot across a list of characters",
+    )
+    distribute.add_argument("amount", type=float)
+    distribute.add_argument("characters", nargs="+", help="Characters sharing the loot")
+    distribute.add_argument("--reason", default="Split loot")
+    distribute.add_argument(
+        "--category",
+        choices=[c.value for c in EventCategory],
+        help="Optional event category",
+    )
+    distribute.set_defaults(func=cmd_distribute)
+
+    return parser
+
+
+def main(argv: Iterable[str] | None = None) -> None:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    args.func(args)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/src/dndbank/exceptions.py
+++ b/src/dndbank/exceptions.py
@@ -1,0 +1,15 @@
+"""Custom error hierarchy for the DnDBank domain."""
+
+from __future__ import annotations
+
+
+class CharacterAlreadyExistsError(ValueError):
+    """Raised when trying to register a duplicate adventurer."""
+
+
+class CharacterNotFoundError(LookupError):
+    """Raised when an unknown adventurer is requested."""
+
+
+class InsufficientFundsError(RuntimeError):
+    """Raised when an operation would drive an account negative."""

--- a/src/dndbank/models.py
+++ b/src/dndbank/models.py
@@ -1,0 +1,51 @@
+"""Core dataclasses and enums used across the DnDBank domain."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from decimal import Decimal
+from enum import Enum
+from typing import Mapping
+
+
+class TransactionType(str, Enum):
+    """Classifies the type of movement recorded in the ledger."""
+
+    EARN = "earn"
+    SPEND = "spend"
+    TRANSFER_IN = "transfer_in"
+    TRANSFER_OUT = "transfer_out"
+    ADJUSTMENT = "adjustment"
+
+
+class EventCategory(str, Enum):
+    """Categorises how gold was gained or spent."""
+
+    QUEST = "quest"
+    LOOT = "loot"
+    PURCHASE = "purchase"
+    DOWNTIME = "downtime"
+    MANUAL = "manual"
+
+
+@dataclass(frozen=True)
+class Transaction:
+    """Immutable record of a single ledger entry."""
+
+    amount: Decimal
+    type: TransactionType
+    description: str
+    category: EventCategory
+    timestamp: datetime
+    metadata: Mapping[str, str] = field(default_factory=dict)
+
+    def as_dict(self) -> dict[str, str]:
+        return {
+            "amount": str(self.amount),
+            "type": self.type.value,
+            "description": self.description,
+            "category": self.category.value,
+            "timestamp": self.timestamp.isoformat(),
+            "metadata": dict(self.metadata),
+        }

--- a/src/dndbank/money.py
+++ b/src/dndbank/money.py
@@ -1,0 +1,45 @@
+"""Helpers for working with monetary values in gold pieces."""
+
+from __future__ import annotations
+
+from decimal import Decimal, ROUND_HALF_UP
+from typing import Union
+
+AmountLike = Union[Decimal, int, float, str]
+
+
+_TWO_PLACES = Decimal("0.01")
+
+
+def to_decimal(value: AmountLike) -> Decimal:
+    """Convert a loose gold piece value into a two-decimal Decimal."""
+
+    if isinstance(value, Decimal):
+        result = value
+    elif isinstance(value, (int, float)):
+        result = Decimal(str(value))
+    elif isinstance(value, str):
+        result = Decimal(value)
+    else:
+        raise TypeError(f"Unsupported amount type: {type(value)!r}")
+
+    return result.quantize(_TWO_PLACES, rounding=ROUND_HALF_UP)
+
+
+def require_positive(value: Decimal, *, allow_zero: bool = False) -> None:
+    """Ensure an amount is positive (or optionally zero)."""
+
+    if allow_zero:
+        if value < Decimal("0"):
+            raise ValueError("Amount must be zero or greater.")
+    else:
+        if value <= Decimal("0"):
+            raise ValueError("Amount must be greater than zero.")
+
+
+def format_gp(value: AmountLike) -> str:
+    """Render a gold piece amount as a string."""
+
+    dec_value = to_decimal(value)
+    normalized = dec_value.quantize(_TWO_PLACES)
+    return f"{normalized} gp"

--- a/src/dndbank/service.py
+++ b/src/dndbank/service.py
@@ -1,0 +1,135 @@
+"""High-level facade for orchestrating character accounts."""
+
+from __future__ import annotations
+
+from decimal import Decimal, ROUND_DOWN
+from typing import Iterable, Mapping, Optional, Tuple
+
+from .account import CharacterAccount
+from .exceptions import CharacterAlreadyExistsError, CharacterNotFoundError
+from .models import EventCategory, Transaction
+from .money import AmountLike, to_decimal
+
+
+class DnDBank:
+    """Manage a party's collection of ``CharacterAccount`` objects."""
+
+    __slots__ = ("_accounts",)
+
+    @classmethod
+    def from_serialized(cls, payload: Mapping[str, object]) -> "DnDBank":
+        bank = cls()
+        for raw in payload.get("characters", []):
+            account = CharacterAccount.from_serialized(raw)
+            bank._accounts[account.name] = account
+        return bank
+
+    def __init__(self) -> None:
+        self._accounts: dict[str, CharacterAccount] = {}
+
+    def list_characters(self) -> Tuple[str, ...]:
+        """Return character names in alphabetical order."""
+
+        return tuple(sorted(self._accounts))
+
+    def create_character(
+        self,
+        name: str,
+        *,
+        player: str | None = None,
+        starting_gold: AmountLike = 0,
+    ) -> CharacterAccount:
+        if name in self._accounts:
+            raise CharacterAlreadyExistsError(f"Character '{name}' already exists.")
+        account = CharacterAccount(name, player=player, starting_gold=starting_gold)
+        self._accounts[name] = account
+        return account
+
+    def get_character(self, name: str) -> CharacterAccount:
+        try:
+            return self._accounts[name]
+        except KeyError as exc:
+            raise CharacterNotFoundError(name) from exc
+
+    def earn_gold(
+        self,
+        name: str,
+        amount: AmountLike,
+        description: str = "Treasure haul",
+        *,
+        category: EventCategory | None = None,
+        metadata: Optional[Mapping[str, str]] = None,
+    ) -> Transaction:
+        character = self.get_character(name)
+        return character.earn(amount, description, category=category, metadata=metadata)
+
+    def spend_gold(
+        self,
+        name: str,
+        amount: AmountLike,
+        description: str = "Purchase",
+        *,
+        category: EventCategory | None = None,
+        metadata: Optional[Mapping[str, str]] = None,
+    ) -> Transaction:
+        character = self.get_character(name)
+        return character.spend(amount, description, category=category, metadata=metadata)
+
+    def transfer_gold(
+        self,
+        source: str,
+        target: str,
+        amount: AmountLike,
+        description: str | None = None,
+        *,
+        metadata: Optional[Mapping[str, str]] = None,
+    ) -> tuple[Transaction, Transaction]:
+        source_account = self.get_character(source)
+        target_account = self.get_character(target)
+        if source_account is target_account:
+            raise ValueError("Cannot transfer to the same character.")
+        return source_account.transfer_to(
+            target_account,
+            amount,
+            description,
+            metadata=metadata,
+        )
+
+    def distribute_loot(
+        self,
+        names: Iterable[str],
+        *,
+        total_amount: AmountLike,
+        description: str = "Split loot",
+        category: EventCategory = EventCategory.LOOT,
+    ) -> tuple[Transaction, ...]:
+        accounts = [self.get_character(name) for name in names]
+        if not accounts:
+            return tuple()
+
+        total_value = to_decimal(total_amount)
+        share = (total_value / len(accounts)).quantize(Decimal("0.01"), rounding=ROUND_DOWN)
+        remainder = total_value - (share * len(accounts))
+
+        transactions: list[Transaction] = []
+        for account in accounts:
+            top_up = Decimal("0")
+            if remainder > Decimal("0"):
+                top_up = Decimal("0.01")
+                remainder -= top_up
+            transactions.append(
+                account.earn(
+                    share + top_up,
+                    description,
+                    category=category,
+                    metadata={"distribution": "loot"},
+                )
+            )
+        return tuple(transactions)
+
+    def to_serialized(self) -> dict[str, object]:
+        return {
+            "characters": [
+                self._accounts[name].to_serialized() for name in self.list_characters()
+            ]
+        }

--- a/src/dndbank/static/style.css
+++ b/src/dndbank/static/style.css
@@ -1,0 +1,285 @@
+:root {
+  color-scheme: light dark;
+  font-family: "Inter", "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  background-color: #121318;
+  color: #f5f5f5;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: radial-gradient(circle at top left, rgba(72, 99, 160, 0.35), transparent 60%),
+              radial-gradient(circle at bottom right, rgba(180, 112, 62, 0.35), transparent 55%),
+              #10121a;
+  display: flex;
+  flex-direction: column;
+}
+
+.hero {
+  padding: 2.5rem 4vw 1.5rem;
+  background: linear-gradient(135deg, rgba(32, 42, 74, 0.9), rgba(82, 50, 31, 0.9));
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  text-align: center;
+}
+
+.hero h1 {
+  margin: 0;
+  font-size: clamp(2rem, 5vw, 3rem);
+  letter-spacing: 0.05em;
+}
+
+.hero p {
+  margin: 0.5rem 0;
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.hero .total {
+  margin-top: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: #ffd37b;
+}
+
+.layout {
+  display: grid;
+  grid-template-columns: minmax(0, 2.5fr) minmax(0, 1.2fr);
+  gap: 2rem;
+  padding: 2rem 4vw 3rem;
+  width: min(1200px, 100%);
+  margin: 0 auto;
+  flex: 1;
+}
+
+.panel {
+  background: rgba(20, 22, 30, 0.85);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 16px;
+  padding: 1.75rem;
+  box-shadow: 0 30px 70px rgba(0, 0, 0, 0.2);
+  backdrop-filter: blur(12px);
+}
+
+.panel h2 {
+  margin-top: 0;
+  font-size: 1.4rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.balances {
+  width: 100%;
+  border-collapse: collapse;
+  margin-bottom: 1.5rem;
+}
+
+.balances th,
+.balances td {
+  padding: 0.75rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.balances th {
+  text-align: left;
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  letter-spacing: 0.15em;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.balances td.number {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+.cards {
+  display: grid;
+  gap: 1.25rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.card {
+  background: rgba(12, 14, 20, 0.85);
+  border-radius: 12px;
+  padding: 1.25rem;
+  border: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.card header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  margin-bottom: 1rem;
+}
+
+.card .meta {
+  font-size: 0.8rem;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.transactions {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.transactions li {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.transactions .amount {
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  padding: 0.25rem 0.5rem;
+  border-radius: 6px;
+  min-width: 90px;
+  text-align: right;
+}
+
+.transactions .amount.earn,
+.transactions .amount.transfer_in {
+  background: rgba(53, 142, 94, 0.18);
+  color: #5de3a8;
+}
+
+.transactions .amount.spend,
+.transactions .amount.transfer_out {
+  background: rgba(180, 86, 72, 0.18);
+  color: #ff9b7d;
+}
+
+.transactions .amount.adjustment {
+  background: rgba(95, 121, 184, 0.18);
+  color: #a9c7ff;
+}
+
+.transactions .details strong {
+  display: block;
+  font-weight: 600;
+}
+
+.transactions .details .meta {
+  font-size: 0.75rem;
+  color: rgba(255, 255, 255, 0.55);
+}
+
+.actions {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.form.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 0.75rem;
+}
+
+label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  font-size: 0.9rem;
+}
+
+input,
+select,
+button {
+  font: inherit;
+  padding: 0.55rem 0.75rem;
+  border-radius: 8px;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  background: rgba(0, 0, 0, 0.25);
+  color: inherit;
+}
+
+input:focus,
+select:focus,
+button:focus {
+  outline: 2px solid rgba(255, 211, 123, 0.6);
+  outline-offset: 2px;
+}
+
+button {
+  cursor: pointer;
+  background: linear-gradient(135deg, #d89b4e, #c7683e);
+  border: none;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+button:hover {
+  filter: brightness(1.1);
+}
+
+small {
+  font-size: 0.75rem;
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.messages {
+  list-style: none;
+  margin: 1rem auto 0;
+  padding: 0;
+  max-width: min(960px, 90%);
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.message {
+  padding: 0.75rem 1rem;
+  border-radius: 8px;
+  font-weight: 600;
+}
+
+.message.success {
+  background: rgba(53, 142, 94, 0.18);
+  color: #5de3a8;
+  border: 1px solid rgba(93, 227, 168, 0.3);
+}
+
+.message.error {
+  background: rgba(180, 86, 72, 0.18);
+  color: #ff9b7d;
+  border: 1px solid rgba(255, 155, 125, 0.3);
+}
+
+.empty {
+  color: rgba(255, 255, 255, 0.55);
+  font-style: italic;
+}
+
+.footer {
+  padding: 1.5rem 0;
+  text-align: center;
+  color: rgba(255, 255, 255, 0.5);
+  font-size: 0.85rem;
+}
+
+.footer a {
+  color: #ffd37b;
+}
+
+@media (max-width: 960px) {
+  .layout {
+    grid-template-columns: 1fr;
+  }
+
+  .actions {
+    order: -1;
+  }
+}

--- a/src/dndbank/templates/dashboard.html
+++ b/src/dndbank/templates/dashboard.html
@@ -1,0 +1,240 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>D&D Bank Ledger</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+  </head>
+  <body>
+    <header class="hero">
+      <h1>KidBank for Adventurers</h1>
+      <p>Track treasure, expenses, and transfers for your entire party.</p>
+      <div class="total">Total party wealth: <strong>{{ total_balance|format_gp }}</strong></div>
+    </header>
+
+    {% with messages = get_flashed_messages(with_categories=true) %}
+      {% if messages %}
+        <ul class="messages">
+          {% for category, message in messages %}
+            <li class="message {{ category }}">{{ message }}</li>
+          {% endfor %}
+        </ul>
+      {% endif %}
+    {% endwith %}
+
+    <main class="layout">
+      <section class="panel ledger">
+        <h2>Party Ledger</h2>
+        {% if characters %}
+          <table class="balances">
+            <thead>
+              <tr>
+                <th>Adventurer</th>
+                <th>Player</th>
+                <th class="number">Balance</th>
+              </tr>
+            </thead>
+            <tbody>
+              {% for character in characters %}
+                <tr>
+                  <td>{{ character.name }}</td>
+                  <td>{{ character.player or '—' }}</td>
+                  <td class="number">{{ character.balance|format_gp }}</td>
+                </tr>
+              {% endfor %}
+            </tbody>
+          </table>
+
+          <div class="cards">
+            {% for character in characters %}
+              <article class="card">
+                <header>
+                  <h3>{{ character.name }}</h3>
+                  {% if character.player %}
+                    <span class="meta">Player: {{ character.player }}</span>
+                  {% endif %}
+                  <span class="meta">Balance: {{ character.balance|format_gp }}</span>
+                </header>
+                {% if character.recent %}
+                  <ul class="transactions">
+                    {% for txn in character.recent %}
+                      <li>
+                        <span class="amount {{ txn.type }}">{{ txn.amount|format_gp }}</span>
+                        <div class="details">
+                          <strong>{{ txn.description }}</strong>
+                          <span class="meta">{{ txn.category.value }} · {{ txn.timestamp.strftime('%Y-%m-%d %H:%M') }}</span>
+                        </div>
+                      </li>
+                    {% endfor %}
+                  </ul>
+                {% else %}
+                  <p class="empty">No transactions yet.</p>
+                {% endif %}
+              </article>
+            {% endfor %}
+          </div>
+        {% else %}
+          <p class="empty">No adventurers yet. Use the form to the right to create your first ledger entry.</p>
+        {% endif %}
+      </section>
+
+      <aside class="panel actions">
+        <section>
+          <h2>Add an adventurer</h2>
+          <form method="post" action="{{ url_for('create_character') }}" class="form">
+            <label>
+              Character name
+              <input type="text" name="name" required>
+            </label>
+            <label>
+              Player
+              <input type="text" name="player" placeholder="Optional">
+            </label>
+            <label>
+              Starting gold
+              <input type="number" step="0.01" min="0" name="starting_gold" value="0">
+            </label>
+            <button type="submit">Create adventurer</button>
+          </form>
+        </section>
+
+        <section>
+          <h2>Record loot</h2>
+          <form method="post" action="{{ url_for('earn_gold') }}" class="form">
+            <label>
+              Character
+              <select name="name" required>
+                <option value="">Select</option>
+                {% for character in characters %}
+                  <option value="{{ character.name }}">{{ character.name }}</option>
+                {% endfor %}
+              </select>
+            </label>
+            <label>
+              Amount
+              <input type="number" step="0.01" min="0.01" name="amount" required>
+            </label>
+            <label>
+              Reason
+              <input type="text" name="reason" value="Treasure haul">
+            </label>
+            <label>
+              Category
+              <select name="category">
+                <option value="">Auto (loot)</option>
+                {% for category in categories %}
+                  <option value="{{ category.value }}">{{ category.value.title() }}</option>
+                {% endfor %}
+              </select>
+            </label>
+            <button type="submit">Add loot</button>
+          </form>
+        </section>
+
+        <section>
+          <h2>Log spending</h2>
+          <form method="post" action="{{ url_for('spend_gold') }}" class="form">
+            <label>
+              Character
+              <select name="name" required>
+                <option value="">Select</option>
+                {% for character in characters %}
+                  <option value="{{ character.name }}">{{ character.name }}</option>
+                {% endfor %}
+              </select>
+            </label>
+            <label>
+              Amount
+              <input type="number" step="0.01" min="0.01" name="amount" required>
+            </label>
+            <label>
+              Reason
+              <input type="text" name="reason" value="Purchase">
+            </label>
+            <label>
+              Category
+              <select name="category">
+                <option value="">Auto (purchase)</option>
+                {% for category in categories %}
+                  <option value="{{ category.value }}">{{ category.value.title() }}</option>
+                {% endfor %}
+              </select>
+            </label>
+            <button type="submit">Log expense</button>
+          </form>
+        </section>
+
+        <section>
+          <h2>Transfer between party members</h2>
+          <form method="post" action="{{ url_for('transfer_gold') }}" class="form grid">
+            <label>
+              From
+              <select name="source" required>
+                <option value="">Select</option>
+                {% for character in characters %}
+                  <option value="{{ character.name }}">{{ character.name }}</option>
+                {% endfor %}
+              </select>
+            </label>
+            <label>
+              To
+              <select name="target" required>
+                <option value="">Select</option>
+                {% for character in characters %}
+                  <option value="{{ character.name }}">{{ character.name }}</option>
+                {% endfor %}
+              </select>
+            </label>
+            <label>
+              Amount
+              <input type="number" step="0.01" min="0.01" name="amount" required>
+            </label>
+            <label>
+              Note
+              <input type="text" name="reason" placeholder="Optional">
+            </label>
+            <button type="submit">Transfer</button>
+          </form>
+        </section>
+
+        <section>
+          <h2>Split treasure haul</h2>
+          <form method="post" action="{{ url_for('distribute_loot') }}" class="form">
+            <label>
+              Adventurers
+              <select name="characters" multiple size="5" required>
+                {% for character in characters %}
+                  <option value="{{ character.name }}">{{ character.name }}</option>
+                {% endfor %}
+              </select>
+              <small>Select one or more characters (Ctrl/Command + click).</small>
+            </label>
+            <label>
+              Total amount
+              <input type="number" step="0.01" min="0.01" name="amount" required>
+            </label>
+            <label>
+              Reason
+              <input type="text" name="reason" value="Split loot">
+            </label>
+            <label>
+              Category
+              <select name="category">
+                <option value="loot" selected>Loot</option>
+                {% for category in categories %}
+                  <option value="{{ category.value }}">{{ category.value.title() }}</option>
+                {% endfor %}
+              </select>
+            </label>
+            <button type="submit">Distribute evenly</button>
+          </form>
+        </section>
+      </aside>
+    </main>
+
+    <footer class="footer">
+      Built to feel like <a href="https://github.com/IrishSpear/kidbank" target="_blank" rel="noopener">KidBank</a> but tailored for D&D treasure tracking.
+    </footer>
+  </body>
+</html>

--- a/src/dndbank/web.py
+++ b/src/dndbank/web.py
@@ -1,0 +1,205 @@
+"""Flask-powered web interface that mirrors the KidBank experience."""
+
+from __future__ import annotations
+
+import json
+import os
+from decimal import Decimal
+from functools import wraps
+from pathlib import Path
+from typing import Any, Callable, Iterable
+
+from flask import (
+    Flask,
+    flash,
+    redirect,
+    render_template,
+    request,
+    url_for,
+)
+
+from .exceptions import (
+    CharacterAlreadyExistsError,
+    CharacterNotFoundError,
+    InsufficientFundsError,
+)
+from .models import EventCategory
+from .money import format_gp
+from .service import DnDBank
+
+
+def create_app(config: dict[str, Any] | None = None) -> Flask:
+    """Create and configure the KidBank-style D&D ledger web app."""
+
+    app = Flask(
+        __name__,
+        instance_relative_config=True,
+        template_folder="templates",
+        static_folder="static",
+    )
+    app.config.from_mapping(
+        SECRET_KEY=os.environ.get("DND_BANK_SECRET_KEY", "dev"),
+        LEDGER_PATH="dnd_ledger.json",
+    )
+    if config:
+        app.config.update(config)
+
+    Path(app.instance_path).mkdir(parents=True, exist_ok=True)
+
+    def ledger_path() -> Path:
+        raw_path = app.config["LEDGER_PATH"]
+        path = raw_path if isinstance(raw_path, Path) else Path(raw_path)
+        if not path.is_absolute():
+            path = Path(app.instance_path) / path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        return path
+
+    def load_bank() -> DnDBank:
+        path = ledger_path()
+        if not path.exists():
+            return DnDBank()
+        data = json.loads(path.read_text())
+        return DnDBank.from_serialized(data)
+
+    def save_bank(bank: DnDBank) -> None:
+        path = ledger_path()
+        path.write_text(json.dumps(bank.to_serialized(), indent=2))
+
+    def post_action(fn: Callable[[DnDBank], None]) -> Callable[[], Any]:
+        @wraps(fn)
+        def wrapper() -> Any:
+            bank = load_bank()
+            try:
+                fn(bank)
+            except ValueError as exc:
+                flash(str(exc), "error")
+            except CharacterAlreadyExistsError as exc:
+                flash(str(exc), "error")
+            except (CharacterNotFoundError, InsufficientFundsError) as exc:
+                flash(str(exc), "error")
+            else:
+                save_bank(bank)
+            return redirect(url_for("dashboard"))
+
+        return wrapper
+
+    @app.template_filter("format_gp")
+    def format_gp_filter(value: object) -> str:
+        return format_gp(value)
+
+    @app.context_processor
+    def inject_categories() -> dict[str, Iterable[EventCategory]]:
+        return {"categories": list(EventCategory)}
+
+    @app.route("/")
+    def dashboard() -> str:
+        bank = load_bank()
+        characters = []
+        total = Decimal("0")
+        for name in bank.list_characters():
+            account = bank.get_character(name)
+            total += account.balance
+            history = list(account.transactions)
+            characters.append(
+                {
+                    "name": account.name,
+                    "player": account.player,
+                    "balance": account.balance,
+                    "recent": history[-5:][::-1],
+                }
+            )
+        return render_template(
+            "dashboard.html",
+            characters=characters,
+            total_balance=total,
+        )
+
+    @app.post("/characters")
+    @post_action
+    def create_character(bank: DnDBank) -> None:
+        name = request.form.get("name", "").strip()
+        player = request.form.get("player", "").strip() or None
+        gold = request.form.get("starting_gold", "0").strip() or "0"
+        if not name:
+            raise ValueError("Character name is required.")
+        bank.create_character(name, player=player, starting_gold=gold)
+        flash(f"Created {name}.", "success")
+
+    @app.post("/earn")
+    @post_action
+    def earn_gold(bank: DnDBank) -> None:
+        name = request.form.get("name", "").strip()
+        amount = request.form.get("amount", "0").strip() or "0"
+        reason = request.form.get("reason", "Treasure haul")
+        category_raw = request.form.get("category")
+        category = EventCategory(category_raw) if category_raw else None
+        if not name:
+            raise ValueError("Select a character to award loot to.")
+        txn = bank.earn_gold(name, amount, description=reason, category=category)
+        flash(
+            f"{name} gained {format_gp(txn.amount)} for {txn.description}.",
+            "success",
+        )
+
+    @app.post("/spend")
+    @post_action
+    def spend_gold(bank: DnDBank) -> None:
+        name = request.form.get("name", "").strip()
+        amount = request.form.get("amount", "0").strip() or "0"
+        reason = request.form.get("reason", "Purchase")
+        category_raw = request.form.get("category")
+        category = EventCategory(category_raw) if category_raw else None
+        if not name:
+            raise ValueError("Select a character to spend from.")
+        txn = bank.spend_gold(name, amount, description=reason, category=category)
+        flash(
+            f"{name} spent {format_gp(txn.amount)} on {txn.description}.",
+            "success",
+        )
+
+    @app.post("/transfer")
+    @post_action
+    def transfer_gold(bank: DnDBank) -> None:
+        source = request.form.get("source", "").strip()
+        target = request.form.get("target", "").strip()
+        amount = request.form.get("amount", "0").strip() or "0"
+        reason = request.form.get("reason") or None
+        if not source or not target:
+            raise ValueError("Select both source and target characters.")
+        bank.transfer_gold(source, target, amount, description=reason)
+        flash(
+            f"Transferred {format_gp(amount)} from {source} to {target}.",
+            "success",
+        )
+
+    @app.post("/distribute")
+    @post_action
+    def distribute_loot(bank: DnDBank) -> None:
+        names = request.form.getlist("characters")
+        amount = request.form.get("amount", "0").strip() or "0"
+        reason = request.form.get("reason", "Split loot")
+        category_raw = request.form.get("category")
+        category = EventCategory(category_raw) if category_raw else EventCategory.LOOT
+        if not names:
+            raise ValueError("Select at least one adventurer to split loot amongst.")
+        bank.distribute_loot(
+            names,
+            total_amount=amount,
+            description=reason,
+            category=category,
+        )
+        flash(
+            f"Split {format_gp(amount)} across {', '.join(names)}.",
+            "success",
+        )
+
+    return app
+
+
+def main() -> None:
+    app = create_app()
+    app.run(debug=True)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual launch helper
+    main()

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -1,0 +1,51 @@
+from decimal import Decimal
+
+import pytest
+
+from dndbank.account import CharacterAccount
+from dndbank.exceptions import InsufficientFundsError
+from dndbank.models import EventCategory, TransactionType
+
+
+def test_starting_balance_records_adjustment_transaction():
+    account = CharacterAccount("Mira", starting_gold=5)
+
+    assert account.balance == Decimal("5.00")
+    assert len(account.transactions) == 1
+    initial = account.transactions[0]
+    assert initial.type is TransactionType.ADJUSTMENT
+    assert initial.amount == Decimal("5.00")
+
+
+def test_earn_adds_to_balance_and_history():
+    account = CharacterAccount("Talen")
+
+    txn = account.earn(10, "Quest reward", category=EventCategory.QUEST)
+
+    assert account.balance == Decimal("10.00")
+    assert txn in account.transactions
+    assert txn.category is EventCategory.QUEST
+    assert txn.type is TransactionType.EARN
+
+
+def test_spend_requires_sufficient_balance():
+    account = CharacterAccount("Nyx", starting_gold=3)
+
+    with pytest.raises(InsufficientFundsError):
+        account.spend(10)
+
+    spent = account.spend(2, "Potion")
+    assert account.balance == Decimal("1.00")
+    assert spent.type is TransactionType.SPEND
+
+
+def test_transfer_between_accounts():
+    source = CharacterAccount("Thorn", starting_gold=12)
+    target = CharacterAccount("Elira")
+
+    outgoing, incoming = source.transfer_to(target, 5, description="Shared expenses")
+
+    assert source.balance == Decimal("7.00")
+    assert target.balance == Decimal("5.00")
+    assert outgoing.type is TransactionType.TRANSFER_OUT
+    assert incoming.type is TransactionType.TRANSFER_IN

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1,0 +1,71 @@
+from decimal import Decimal
+
+import pytest
+
+from dndbank import DnDBank, EventCategory
+from dndbank.exceptions import CharacterAlreadyExistsError, CharacterNotFoundError
+
+
+def test_create_and_list_characters():
+    bank = DnDBank()
+
+    bank.create_character("Aelin", player="Sam", starting_gold=10)
+    bank.create_character("Fen", starting_gold=0)
+
+    assert bank.list_characters() == ("Aelin", "Fen")
+    assert bank.get_character("Aelin").player == "Sam"
+
+
+def test_duplicate_character_raises():
+    bank = DnDBank()
+    bank.create_character("Rowan")
+
+    with pytest.raises(CharacterAlreadyExistsError):
+        bank.create_character("Rowan")
+
+
+def test_transfer_and_spend_flow():
+    bank = DnDBank()
+    bank.create_character("Lyra", starting_gold=15)
+    bank.create_character("Iliad")
+
+    bank.transfer_gold("Lyra", "Iliad", 5)
+    bank.spend_gold("Iliad", 3, description="Supplies")
+
+    assert bank.get_character("Lyra").balance == Decimal("10.00")
+    assert bank.get_character("Iliad").balance == Decimal("2.00")
+
+
+def test_distribute_loot_evenly():
+    bank = DnDBank()
+    bank.create_character("Morrigan")
+    bank.create_character("Nesta")
+    bank.create_character("Elain")
+
+    txns = bank.distribute_loot(["Morrigan", "Nesta", "Elain"], total_amount=5)
+
+    assert len(txns) == 3
+    assert all(t.category is EventCategory.LOOT for t in txns)
+    totals = [bank.get_character(name).balance for name in ("Morrigan", "Nesta", "Elain")]
+    assert totals == [Decimal("1.67"), Decimal("1.67"), Decimal("1.66")]
+
+
+def test_serialization_round_trip():
+    bank = DnDBank()
+    bank.create_character("Dorian", starting_gold=2)
+    bank.earn_gold("Dorian", 3, description="Contract")
+
+    payload = bank.to_serialized()
+    restored = DnDBank.from_serialized(payload)
+
+    assert restored.list_characters() == ("Dorian",)
+    restored_account = restored.get_character("Dorian")
+    assert restored_account.balance == bank.get_character("Dorian").balance
+    assert len(restored_account.transactions) == len(bank.get_character("Dorian").transactions)
+
+
+def test_missing_character_raises_lookup_error():
+    bank = DnDBank()
+
+    with pytest.raises(CharacterNotFoundError):
+        bank.get_character("Unknown")

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from dndbank.web import create_app
+
+
+def make_app(tmp_path: Path):
+    ledger = tmp_path / "ledger.json"
+    app = create_app({
+        "TESTING": True,
+        "SECRET_KEY": "test",
+        "LEDGER_PATH": ledger,
+    })
+    return app, ledger
+
+
+def test_dashboard_renders_without_characters(tmp_path):
+    app, _ = make_app(tmp_path)
+    client = app.test_client()
+
+    response = client.get("/")
+
+    assert response.status_code == 200
+    assert b"No adventurers yet" in response.data
+
+
+def test_full_web_flow_persists_to_ledger(tmp_path):
+    app, ledger = make_app(tmp_path)
+    client = app.test_client()
+
+    client.post(
+        "/characters",
+        data={"name": "Aria", "player": "Alice", "starting_gold": "100"},
+        follow_redirects=True,
+    )
+    client.post(
+        "/characters",
+        data={"name": "Borin", "player": "", "starting_gold": "0"},
+        follow_redirects=True,
+    )
+    client.post(
+        "/earn",
+        data={"name": "Aria", "amount": "50", "reason": "Quest reward", "category": "quest"},
+        follow_redirects=True,
+    )
+    client.post(
+        "/spend",
+        data={"name": "Aria", "amount": "10", "reason": "Potion", "category": "purchase"},
+        follow_redirects=True,
+    )
+    client.post(
+        "/transfer",
+        data={"source": "Aria", "target": "Borin", "amount": "25", "reason": "Share"},
+        follow_redirects=True,
+    )
+    client.post(
+        "/distribute",
+        data={"characters": ["Aria", "Borin"], "amount": "20", "reason": "Loot split", "category": "loot"},
+        follow_redirects=True,
+    )
+
+    assert ledger.exists()
+    data = json.loads(ledger.read_text())
+    characters = {entry["name"]: entry for entry in data["characters"]}
+
+    assert characters["Aria"]["balance"] == "125.00"
+    assert characters["Borin"]["balance"] == "35.00"
+
+    # Ensure the dashboard reflects the updates
+    response = client.get("/")
+    body = response.data.decode()
+    assert "Aria" in body
+    assert "Borin" in body
+    assert "125.00 gp" in body
+    assert "35.00 gp" in body
+
+
+def test_invalid_form_shows_error(tmp_path):
+    app, _ = make_app(tmp_path)
+    client = app.test_client()
+
+    response = client.post(
+        "/earn",
+        data={"name": "", "amount": "5"},
+        follow_redirects=True,
+    )
+
+    assert response.status_code == 200
+    assert "Select a character to award loot to." in response.get_data(as_text=True)


### PR DESCRIPTION
## Summary
- replace the standalone script with a src/ package that mirrors KidBank's architecture
- add CharacterAccount, DnDBank, money helpers, and an argparse CLI that persists ledgers to JSON
- add pytest-based coverage for account, service, and serialization flows and document the new layout in the README

## Testing
- python -m pytest


------
https://chatgpt.com/codex/tasks/task_e_68d75aaffec8832ea040400d0ac83a55