### PR TITLE
Expand DnDBank with character sheets and inventory tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Another D&D Tool
 
-This project mirrors the structure of the original [KidBank](https://github.com/IrishSpear/kidbank) app while focusing on tabletop parties instead of kids' allowances. It now ships with a FastAPI-powered web dashboard, well-tested domain objects, a high-level service façade, and a lightweight CLI for persisting gold ledgers to disk.
+This project mirrors the structure of the original [KidBank](https://github.com/IrishSpear/kidbank) app while focusing on tabletop parties instead of kids' allowances. It now ships with a FastAPI-powered web dashboard, well-tested domain objects, a high-level service façade, and a lightweight CLI for persisting gold ledgers to disk. Beyond party finances, the toolkit now understands character sheets, hit point tracking, and inventory management so you can run an entire campaign ledger from one place.
 
 ## Project structure
 
@@ -8,10 +8,10 @@ This project mirrors the structure of the original [KidBank](https://github.com/
 src/
   dndbank/
     __init__.py        # Public exports (DnDBank, models, exceptions)
-    account.py         # CharacterAccount domain logic
+    account.py         # CharacterAccount domain logic (gold, sheets, inventory)
     cli.py             # Argparse CLI for working with JSON ledgers
     exceptions.py      # Error hierarchy
-    models.py          # Dataclasses and enums describing transactions
+    models.py          # Dataclasses and enums describing transactions, sheets, items
     money.py           # Decimal helpers for gold piece arithmetic
     service.py         # DnDBank façade coordinating accounts
 pytest.ini             # Configures pytest to discover src/ package
@@ -94,4 +94,22 @@ python -m dndbank.cli history "Mira Quickstep"
 ```
 
 Because the ledger file is plain JSON you can commit it to version control or copy it between machines to keep a party's finances synchronised.
+
+### Track character sheets and inventory
+
+Use the new ``sheet`` command to view or update a character's role-playing information, ability scores, and hit points:
+
+```bash
+python -m dndbank.cli sheet "Sir Galahad" --class Paladin --ancestry Human --level 5 \
+    --ability str=18 --ability cha=16 --hit-points maximum=45 --hit-points current=38
+```
+
+Manage equipment, consumables, and treasures with the ``inventory`` commands:
+
+```bash
+python -m dndbank.cli inventory add "Sir Galahad" "Longsword" --category Weapon --equipped
+python -m dndbank.cli inventory list "Sir Galahad"
+python -m dndbank.cli inventory update "Sir Galahad" "Longsword" --description "Family heirloom"
+python -m dndbank.cli inventory remove "Sir Galahad" "Longsword"
+```
 

--- a/src/dndbank/__init__.py
+++ b/src/dndbank/__init__.py
@@ -6,17 +6,29 @@ from .exceptions import (
     CharacterNotFoundError,
     InsufficientFundsError,
 )
-from .models import EventCategory, Transaction, TransactionType
+from .models import (
+    AbilityScores,
+    CharacterSheet,
+    EventCategory,
+    HitPointPool,
+    InventoryItem,
+    Transaction,
+    TransactionType,
+)
 from .service import DnDBank
 from .web import create_app
 
 __all__ = [
+    "AbilityScores",
     "CharacterAccount",
     "CharacterAlreadyExistsError",
     "CharacterNotFoundError",
+    "CharacterSheet",
     "DnDBank",
     "EventCategory",
+    "HitPointPool",
     "InsufficientFundsError",
+    "InventoryItem",
     "Transaction",
     "TransactionType",
     "create_app",

--- a/src/dndbank/account.py
+++ b/src/dndbank/account.py
@@ -7,14 +7,22 @@ from decimal import Decimal
 from typing import Mapping, Optional, Tuple
 
 from .exceptions import InsufficientFundsError
-from .models import EventCategory, Transaction, TransactionType
+from .models import (
+    AbilityScores,
+    CharacterSheet,
+    EventCategory,
+    HitPointPool,
+    InventoryItem,
+    Transaction,
+    TransactionType,
+)
 from .money import AmountLike, require_positive, to_decimal
 
 
 class CharacterAccount:
     """Represents an adventurer's personal hoard."""
 
-    __slots__ = ("name", "player", "_balance", "_transactions")
+    __slots__ = ("name", "player", "_balance", "_transactions", "_sheet", "_inventory")
 
     @classmethod
     def from_serialized(cls, payload: Mapping[str, object]) -> "CharacterAccount":
@@ -27,6 +35,11 @@ class CharacterAccount:
         )
         account._balance = to_decimal(payload.get("balance", 0))
         account._transactions.clear()
+        account._sheet = CharacterSheet.from_dict(payload.get("sheet", {}))
+        account._inventory.clear()
+        for raw_item in payload.get("inventory", []):
+            item = InventoryItem.from_dict(raw_item)
+            account._inventory[item.name.casefold()] = item
         for raw in payload.get("transactions", []):
             account._transactions.append(
                 Transaction(
@@ -46,6 +59,7 @@ class CharacterAccount:
         *,
         player: str | None = None,
         starting_gold: AmountLike = 0,
+        sheet: CharacterSheet | None = None,
     ) -> None:
         self.name = name
         self.player = player
@@ -53,6 +67,8 @@ class CharacterAccount:
         require_positive(starting_value, allow_zero=True)
         self._balance: Decimal = starting_value
         self._transactions: list[Transaction] = []
+        self._sheet = sheet or CharacterSheet()
+        self._inventory: dict[str, InventoryItem] = {}
 
         if starting_value > Decimal("0"):
             self._log_transaction(
@@ -71,6 +87,14 @@ class CharacterAccount:
     @property
     def transactions(self) -> Tuple[Transaction, ...]:
         return tuple(self._transactions)
+
+    @property
+    def sheet(self) -> CharacterSheet:
+        return self._sheet
+
+    @property
+    def inventory(self) -> Tuple[InventoryItem, ...]:
+        return tuple(self._inventory.values())
 
     def earn(
         self,
@@ -146,6 +170,112 @@ class CharacterAccount:
         )
         return outbound, inbound
 
+    def update_sheet(self, **fields: object) -> CharacterSheet:
+        """Update the character sheet with supplied fields."""
+
+        self._sheet.update(**fields)
+        return self._sheet
+
+    def set_ability_scores(self, **scores: int) -> AbilityScores:
+        self._sheet.ability_scores = self._sheet.ability_scores.updated(**scores)
+        return self._sheet.ability_scores
+
+    def adjust_hit_points(self, delta: int, *, use_temporary: bool = True) -> HitPointPool:
+        pool = self._sheet.hit_points.apply_delta(delta, use_temporary=use_temporary)
+        self._sheet.hit_points = pool
+        return pool
+
+    def set_hit_points(
+        self,
+        *,
+        maximum: int | None = None,
+        current: int | None = None,
+        temporary: int | None = None,
+    ) -> HitPointPool:
+        pool = self._sheet.hit_points.with_updates(
+            maximum=maximum,
+            current=current,
+            temporary=temporary,
+        )
+        self._sheet.hit_points = pool
+        return pool
+
+    def list_inventory(self) -> Tuple[InventoryItem, ...]:
+        return tuple(self._inventory.values())
+
+    def add_inventory_item(
+        self,
+        name: str,
+        *,
+        quantity: int = 1,
+        description: str | None = None,
+        weight: float | None = None,
+        value_gp: AmountLike | None = None,
+        category: str | None = None,
+        equipped: bool | None = None,
+    ) -> InventoryItem:
+        key = name.casefold()
+        existing = self._inventory.get(key)
+        if existing:
+            new_quantity = existing.quantity + quantity
+            updated = existing.with_quantity(new_quantity).with_updates(
+                description=description,
+                weight=weight,
+                value_gp=value_gp,
+                category=category,
+                equipped=equipped,
+            )
+        else:
+            updated = InventoryItem(
+                name=name,
+                quantity=quantity,
+                description=description or "",
+                weight=weight,
+                value_gp=to_decimal(value_gp) if value_gp is not None else None,
+                category=category,
+                equipped=equipped or False,
+            )
+        self._inventory[key] = updated
+        return updated
+
+    def update_inventory_item(
+        self,
+        name: str,
+        *,
+        quantity: int | None = None,
+        description: str | None = None,
+        weight: float | None = None,
+        value_gp: AmountLike | None = None,
+        category: str | None = None,
+        equipped: bool | None = None,
+    ) -> InventoryItem:
+        key = name.casefold()
+        if key not in self._inventory:
+            raise KeyError(f"{self.name} does not carry '{name}'.")
+        item = self._inventory[key]
+        updated = item
+        if quantity is not None:
+            updated = updated.with_quantity(quantity)
+        updated = updated.with_updates(
+            description=description,
+            weight=weight,
+            value_gp=value_gp,
+            category=category,
+            equipped=equipped,
+        )
+        self._inventory[key] = updated
+        return updated
+
+    def remove_inventory_item(self, name: str, *, quantity: int | None = None) -> None:
+        key = name.casefold()
+        if key not in self._inventory:
+            raise KeyError(f"{self.name} does not carry '{name}'.")
+        item = self._inventory[key]
+        if quantity is None or quantity >= item.quantity:
+            del self._inventory[key]
+        else:
+            self._inventory[key] = item.with_quantity(item.quantity - quantity)
+
     def _ensure_sufficient(self, amount: Decimal) -> None:
         if self._balance < amount:
             raise InsufficientFundsError(
@@ -182,5 +312,7 @@ class CharacterAccount:
             "name": self.name,
             "player": self.player,
             "balance": str(self._balance),
+            "sheet": self._sheet.as_dict(),
+            "inventory": [item.as_dict() for item in self._inventory.values()],
             "transactions": [entry.as_dict() for entry in self._transactions],
         }

--- a/src/dndbank/cli.py
+++ b/src/dndbank/cli.py
@@ -12,7 +12,7 @@ from .exceptions import (
     CharacterNotFoundError,
     InsufficientFundsError,
 )
-from .models import EventCategory, TransactionType
+from .models import CharacterSheet, EventCategory, InventoryItem, TransactionType
 from .money import format_gp
 from .service import DnDBank
 
@@ -150,6 +150,203 @@ def cmd_history(args: argparse.Namespace) -> None:
         )
 
 
+def parse_assignments(values: Iterable[str]) -> dict[str, int]:
+    assignments: dict[str, int] = {}
+    for raw in values:
+        if "=" not in raw:
+            raise ValueError(f"Expected KEY=VALUE format for '{raw}'.")
+        key, value = raw.split("=", 1)
+        cleaned_key = key.strip().lower()
+        cleaned_value = value.strip()
+        if not cleaned_key or not cleaned_value:
+            raise ValueError(f"Invalid assignment '{raw}'.")
+        assignments[cleaned_key] = int(cleaned_value)
+    return assignments
+
+
+def render_sheet(name: str, sheet: CharacterSheet) -> None:
+    print(f"{name}'s character sheet")
+    header: list[str] = []
+    if sheet.character_class:
+        header.append(sheet.character_class)
+    if sheet.ancestry:
+        header.append(sheet.ancestry)
+    if sheet.background:
+        header.append(f"Background: {sheet.background}")
+    if sheet.alignment:
+        header.append(f"Alignment: {sheet.alignment}")
+    if header:
+        print(" • ".join(header))
+    print(f"Level {sheet.level} — {sheet.experience} XP — Proficiency +{sheet.proficiency_bonus}")
+    hp = sheet.hit_points
+    hp_line = f"HP {hp.current}/{hp.maximum} (+{hp.temporary} temp)"
+    if sheet.inspiration:
+        hp_line += " — Inspiration"
+    print(hp_line)
+    if sheet.passive_perception is not None:
+        print(f"Passive Perception: {sheet.passive_perception}")
+    ability_parts: list[str] = []
+    for ability, score in sheet.ability_scores.as_dict().items():
+        mod = sheet.ability_scores.modifier(ability)
+        ability_parts.append(f"{ability[:3].title()} {score} ({mod:+d})")
+    print("Abilities: " + ", ".join(ability_parts))
+    if sheet.notes:
+        print(f"Notes: {sheet.notes}")
+
+
+def format_inventory_item(item: InventoryItem) -> str:
+    parts = [f"{item.name} x{item.quantity}"]
+    if item.category:
+        parts.append(f"[{item.category}]")
+    if item.equipped:
+        parts.append("(equipped)")
+    if item.weight is not None:
+        parts.append(f"{item.weight} lb")
+    if item.value_gp is not None:
+        parts.append(format_gp(item.value_gp))
+    if item.description:
+        parts.append(f"— {item.description}")
+    return " ".join(parts)
+
+
+def cmd_sheet(args: argparse.Namespace) -> None:
+    bank = load_bank(args.ledger)
+    try:
+        bank.get_character(args.name)
+    except CharacterNotFoundError as exc:
+        raise SystemExit(str(exc))
+
+    updates: dict[str, object] = {}
+    if args.character_class:
+        updates["character_class"] = args.character_class
+    if args.ancestry:
+        updates["ancestry"] = args.ancestry
+    if args.background:
+        updates["background"] = args.background
+    if args.alignment:
+        updates["alignment"] = args.alignment
+    if args.level is not None:
+        updates["level"] = args.level
+    if args.experience is not None:
+        updates["experience"] = args.experience
+    if args.proficiency is not None:
+        updates["proficiency_bonus"] = args.proficiency
+    if args.passive_perception is not None:
+        updates["passive_perception"] = args.passive_perception
+    if args.notes is not None:
+        updates["notes"] = args.notes
+    if args.inspiration is not None:
+        updates["inspiration"] = args.inspiration
+
+    ability_updates: dict[str, int] = {}
+    hp_updates: dict[str, int] = {}
+    if args.ability:
+        try:
+            ability_updates = parse_assignments(args.ability)
+        except ValueError as exc:
+            raise SystemExit(str(exc))
+        alias_map = {
+            "str": "strength",
+            "dex": "dexterity",
+            "con": "constitution",
+            "int": "intelligence",
+            "wis": "wisdom",
+            "cha": "charisma",
+        }
+        ability_updates = {
+            alias_map.get(key, key): value for key, value in ability_updates.items()
+        }
+    if args.hit_points:
+        try:
+            hp_updates = parse_assignments(args.hit_points)
+        except ValueError as exc:
+            raise SystemExit(str(exc))
+
+    if updates:
+        bank.update_character_sheet(args.name, **updates)
+    if ability_updates:
+        bank.set_ability_scores(args.name, **ability_updates)
+    if hp_updates:
+        bank.set_hit_points(
+            args.name,
+            maximum=hp_updates.get("maximum"),
+            current=hp_updates.get("current"),
+            temporary=hp_updates.get("temporary"),
+        )
+
+    if updates or ability_updates or hp_updates:
+        save_bank(args.ledger, bank)
+        print(f"Updated sheet for {args.name}.")
+
+    render_sheet(args.name, bank.get_character_sheet(args.name))
+
+
+def cmd_inventory_list(args: argparse.Namespace) -> None:
+    bank = load_bank(args.ledger)
+    try:
+        items = bank.list_inventory(args.name)
+    except CharacterNotFoundError as exc:
+        raise SystemExit(str(exc))
+
+    if not items:
+        print(f"{args.name} carries nothing.")
+        return
+
+    for item in items:
+        print(format_inventory_item(item))
+
+
+def cmd_inventory_add(args: argparse.Namespace) -> None:
+    bank = load_bank(args.ledger)
+    try:
+        item = bank.add_inventory_item(
+            args.name,
+            item_name=args.item,
+            quantity=args.quantity,
+            description=args.description,
+            weight=args.weight,
+            value_gp=args.value,
+            category=args.category,
+            equipped=args.equipped,
+        )
+    except (CharacterNotFoundError, ValueError) as exc:
+        raise SystemExit(str(exc))
+    save_bank(args.ledger, bank)
+    print(f"Added {item.name} x{item.quantity} to {args.name}.")
+
+
+def cmd_inventory_update(args: argparse.Namespace) -> None:
+    bank = load_bank(args.ledger)
+    try:
+        item = bank.update_inventory_item(
+            args.name,
+            args.item,
+            quantity=args.quantity,
+            description=args.description,
+            weight=args.weight,
+            value_gp=args.value,
+            category=args.category,
+            equipped=args.equipped,
+        )
+    except (CharacterNotFoundError, KeyError, ValueError) as exc:
+        raise SystemExit(str(exc))
+    save_bank(args.ledger, bank)
+    print(f"Updated {item.name} for {args.name} (now x{item.quantity}).")
+
+
+def cmd_inventory_remove(args: argparse.Namespace) -> None:
+    bank = load_bank(args.ledger)
+    try:
+        bank.remove_inventory_item(args.name, args.item, quantity=args.quantity)
+    except (CharacterNotFoundError, KeyError, ValueError) as exc:
+        raise SystemExit(str(exc))
+    save_bank(args.ledger, bank)
+    if args.quantity is None:
+        print(f"Removed {args.item} from {args.name}.")
+    else:
+        print(f"Removed {args.quantity} of {args.item} from {args.name}.")
+
+
 def cmd_distribute(args: argparse.Namespace) -> None:
     bank = load_bank(args.ledger)
     try:
@@ -230,6 +427,70 @@ def build_parser() -> argparse.ArgumentParser:
         help="Optional event category",
     )
     distribute.set_defaults(func=cmd_distribute)
+
+    sheet = subparsers.add_parser("sheet", help="View or update a character sheet")
+    sheet.add_argument("name")
+    sheet.add_argument("--class", dest="character_class")
+    sheet.add_argument("--ancestry")
+    sheet.add_argument("--background")
+    sheet.add_argument("--alignment")
+    sheet.add_argument("--level", type=int)
+    sheet.add_argument("--experience", type=int)
+    sheet.add_argument("--proficiency", type=int)
+    sheet.add_argument("--passive-perception", dest="passive_perception", type=int)
+    sheet.add_argument("--notes")
+    sheet.add_argument("--inspiration", dest="inspiration", action="store_true")
+    sheet.add_argument("--no-inspiration", dest="inspiration", action="store_false")
+    sheet.add_argument(
+        "--ability",
+        action="append",
+        metavar="ABILITY=VALUE",
+        help="Override an ability score (repeatable)",
+    )
+    sheet.add_argument(
+        "--hit-points",
+        dest="hit_points",
+        action="append",
+        metavar="FIELD=VALUE",
+        help="Adjust hit point pool (current, maximum, temporary)",
+    )
+    sheet.set_defaults(inspiration=None, func=cmd_sheet)
+
+    inventory = subparsers.add_parser("inventory", help="Manage a character's inventory")
+    inv_subparsers = inventory.add_subparsers(dest="inventory_command", required=True)
+
+    inv_list = inv_subparsers.add_parser("list", help="Display carried items")
+    inv_list.add_argument("name")
+    inv_list.set_defaults(func=cmd_inventory_list)
+
+    inv_add = inv_subparsers.add_parser("add", help="Add or increase an item")
+    inv_add.add_argument("name")
+    inv_add.add_argument("item")
+    inv_add.add_argument("--quantity", type=int, default=1)
+    inv_add.add_argument("--description")
+    inv_add.add_argument("--weight", type=float)
+    inv_add.add_argument("--value")
+    inv_add.add_argument("--category")
+    inv_add.add_argument("--equipped", action="store_true")
+    inv_add.set_defaults(func=cmd_inventory_add)
+
+    inv_update = inv_subparsers.add_parser("update", help="Edit an existing item")
+    inv_update.add_argument("name")
+    inv_update.add_argument("item")
+    inv_update.add_argument("--quantity", type=int)
+    inv_update.add_argument("--description")
+    inv_update.add_argument("--weight", type=float)
+    inv_update.add_argument("--value")
+    inv_update.add_argument("--category")
+    inv_update.add_argument("--equipped", action="store_true")
+    inv_update.add_argument("--unequipped", dest="equipped", action="store_false")
+    inv_update.set_defaults(equipped=None, func=cmd_inventory_update)
+
+    inv_remove = inv_subparsers.add_parser("remove", help="Remove an item or reduce quantity")
+    inv_remove.add_argument("name")
+    inv_remove.add_argument("item")
+    inv_remove.add_argument("--quantity", type=int)
+    inv_remove.set_defaults(func=cmd_inventory_remove)
 
     return parser
 

--- a/src/dndbank/models.py
+++ b/src/dndbank/models.py
@@ -6,7 +6,9 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from decimal import Decimal
 from enum import Enum
-from typing import Mapping
+from typing import Mapping, MutableMapping
+
+from .money import AmountLike, to_decimal
 
 
 class TransactionType(str, Enum):
@@ -49,3 +51,272 @@ class Transaction:
             "timestamp": self.timestamp.isoformat(),
             "metadata": dict(self.metadata),
         }
+
+
+@dataclass(frozen=True)
+class AbilityScores:
+    """Represents a standard D&D ability score block."""
+
+    strength: int = 10
+    dexterity: int = 10
+    constitution: int = 10
+    intelligence: int = 10
+    wisdom: int = 10
+    charisma: int = 10
+
+    def __post_init__(self) -> None:
+        for name, value in self.as_dict().items():
+            if not 1 <= value <= 30:
+                raise ValueError(
+                    f"Ability score '{name}' must be between 1 and 30 (got {value})."
+                )
+
+    def modifier(self, ability: str) -> int:
+        """Return the D&D modifier for the requested ability name."""
+
+        lookup = self.as_dict()
+        try:
+            score = lookup[ability.lower()]
+        except KeyError as exc:
+            raise KeyError(f"Unknown ability '{ability}'.") from exc
+        return (score - 10) // 2
+
+    def updated(self, **scores: int) -> "AbilityScores":
+        """Return a new ``AbilityScores`` with the provided overrides."""
+
+        normalized: dict[str, int] = self.as_dict()
+        for key, value in scores.items():
+            lowered = key.lower()
+            if lowered not in normalized:
+                raise KeyError(f"Unknown ability '{key}'.")
+            normalized[lowered] = int(value)
+        return AbilityScores(**normalized)
+
+    def as_dict(self) -> dict[str, int]:
+        return {
+            "strength": self.strength,
+            "dexterity": self.dexterity,
+            "constitution": self.constitution,
+            "intelligence": self.intelligence,
+            "wisdom": self.wisdom,
+            "charisma": self.charisma,
+        }
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, int]) -> "AbilityScores":
+        defaults = cls().as_dict()
+        overrides = {key.lower(): int(value) for key, value in payload.items()}
+        merged = {name: overrides.get(name, default) for name, default in defaults.items()}
+        return cls(**merged)
+
+
+@dataclass(frozen=True)
+class HitPointPool:
+    """Tracks a character's hit point pools."""
+
+    maximum: int = 1
+    current: int = 1
+    temporary: int = 0
+
+    def __post_init__(self) -> None:
+        if self.maximum < 0:
+            raise ValueError("Maximum hit points cannot be negative.")
+        if self.current < 0 or self.temporary < 0:
+            raise ValueError("Hit point values cannot be negative.")
+        if self.current > self.maximum:
+            object.__setattr__(self, "current", self.maximum)
+
+    def apply_delta(self, delta: int, *, use_temporary: bool = True) -> "HitPointPool":
+        """Return a new pool after applying healing or damage."""
+
+        current = self.current
+        temporary = self.temporary
+        if delta >= 0:
+            current = min(self.maximum, current + delta)
+        else:
+            damage = -delta
+            if use_temporary and temporary > 0:
+                absorbed = min(temporary, damage)
+                temporary -= absorbed
+                damage -= absorbed
+            current = max(0, current - damage)
+        return HitPointPool(maximum=self.maximum, current=current, temporary=temporary)
+
+    def with_updates(
+        self,
+        *,
+        maximum: int | None = None,
+        current: int | None = None,
+        temporary: int | None = None,
+    ) -> "HitPointPool":
+        return HitPointPool(
+            maximum=self.maximum if maximum is None else maximum,
+            current=self.current if current is None else current,
+            temporary=self.temporary if temporary is None else temporary,
+        )
+
+    def as_dict(self) -> dict[str, int]:
+        return {
+            "maximum": self.maximum,
+            "current": self.current,
+            "temporary": self.temporary,
+        }
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, int]) -> "HitPointPool":
+        return cls(
+            maximum=int(payload.get("maximum", 1)),
+            current=int(payload.get("current", payload.get("maximum", 1))),
+            temporary=int(payload.get("temporary", 0)),
+        )
+
+
+@dataclass
+class CharacterSheet:
+    """Stores the role-playing details for a character."""
+
+    ancestry: str | None = None
+    character_class: str | None = None
+    background: str | None = None
+    alignment: str | None = None
+    level: int = 1
+    experience: int = 0
+    proficiency_bonus: int = 2
+    ability_scores: AbilityScores = field(default_factory=AbilityScores)
+    hit_points: HitPointPool = field(default_factory=HitPointPool)
+    inspiration: bool = False
+    passive_perception: int | None = None
+    notes: str | None = None
+
+    def update(self, **fields: object) -> "CharacterSheet":
+        """Update sheet fields in-place and return ``self`` for chaining."""
+
+        for key, value in fields.items():
+            if key == "ability_scores":
+                if isinstance(value, AbilityScores):
+                    self.ability_scores = value
+                elif isinstance(value, Mapping):
+                    self.ability_scores = self.ability_scores.updated(**value)
+                else:
+                    raise TypeError("ability_scores must be an AbilityScores or mapping")
+            elif key == "hit_points":
+                if isinstance(value, HitPointPool):
+                    self.hit_points = value
+                elif isinstance(value, Mapping):
+                    self.hit_points = self.hit_points.with_updates(
+                        maximum=value.get("maximum"),
+                        current=value.get("current"),
+                        temporary=value.get("temporary"),
+                    )
+                else:
+                    raise TypeError("hit_points must be a HitPointPool or mapping")
+            elif hasattr(self, key):
+                setattr(self, key, value)
+            else:
+                raise AttributeError(f"Unknown sheet field '{key}'.")
+        return self
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "ancestry": self.ancestry,
+            "character_class": self.character_class,
+            "background": self.background,
+            "alignment": self.alignment,
+            "level": self.level,
+            "experience": self.experience,
+            "proficiency_bonus": self.proficiency_bonus,
+            "ability_scores": self.ability_scores.as_dict(),
+            "hit_points": self.hit_points.as_dict(),
+            "inspiration": self.inspiration,
+            "passive_perception": self.passive_perception,
+            "notes": self.notes,
+        }
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, object]) -> "CharacterSheet":
+        sheet = cls()
+        data: MutableMapping[str, object] = dict(payload)
+        abilities = data.pop("ability_scores", None)
+        hit_points = data.pop("hit_points", None)
+        sheet.update(**data)
+        if abilities:
+            sheet.ability_scores = AbilityScores.from_dict(abilities)
+        if hit_points:
+            sheet.hit_points = HitPointPool.from_dict(hit_points)
+        return sheet
+
+
+@dataclass(frozen=True)
+class InventoryItem:
+    """Represents a single entry on a character's inventory list."""
+
+    name: str
+    quantity: int = 1
+    description: str = ""
+    weight: float | None = None
+    value_gp: Decimal | None = None
+    category: str | None = None
+    equipped: bool = False
+
+    def __post_init__(self) -> None:
+        if self.quantity <= 0:
+            raise ValueError("Item quantity must be positive.")
+
+    def with_quantity(self, quantity: int) -> "InventoryItem":
+        if quantity <= 0:
+            raise ValueError("Item quantity must be positive.")
+        return InventoryItem(
+            name=self.name,
+            quantity=quantity,
+            description=self.description,
+            weight=self.weight,
+            value_gp=self.value_gp,
+            category=self.category,
+            equipped=self.equipped,
+        )
+
+    def with_updates(
+        self,
+        *,
+        description: str | None = None,
+        weight: float | None = None,
+        value_gp: AmountLike | None = None,
+        category: str | None = None,
+        equipped: bool | None = None,
+    ) -> "InventoryItem":
+        return InventoryItem(
+            name=self.name,
+            quantity=self.quantity,
+            description=self.description if description is None else description,
+            weight=self.weight if weight is None else weight,
+            value_gp=self.value_gp if value_gp is None else to_decimal(value_gp),
+            category=self.category if category is None else category,
+            equipped=self.equipped if equipped is None else equipped,
+        )
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "name": self.name,
+            "quantity": self.quantity,
+            "description": self.description,
+            "weight": self.weight,
+            "value_gp": str(self.value_gp) if self.value_gp is not None else None,
+            "category": self.category,
+            "equipped": self.equipped,
+        }
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, object]) -> "InventoryItem":
+        value = payload.get("value_gp")
+        parsed_value = None if value in (None, "") else to_decimal(value)  # type: ignore[arg-type]
+        weight = payload.get("weight")
+        parsed_weight = None if weight in (None, "") else float(weight)
+        return cls(
+            name=str(payload["name"]),
+            quantity=int(payload.get("quantity", 1)),
+            description=str(payload.get("description", "")),
+            weight=parsed_weight,
+            value_gp=parsed_value,
+            category=(payload.get("category") or None),
+            equipped=bool(payload.get("equipped", False)),
+        )

--- a/src/dndbank/service.py
+++ b/src/dndbank/service.py
@@ -7,7 +7,7 @@ from typing import Iterable, Mapping, Optional, Tuple
 
 from .account import CharacterAccount
 from .exceptions import CharacterAlreadyExistsError, CharacterNotFoundError
-from .models import EventCategory, Transaction
+from .models import AbilityScores, CharacterSheet, EventCategory, HitPointPool, InventoryItem, Transaction
 from .money import AmountLike, to_decimal
 
 
@@ -38,10 +38,16 @@ class DnDBank:
         *,
         player: str | None = None,
         starting_gold: AmountLike = 0,
+        sheet: CharacterSheet | None = None,
     ) -> CharacterAccount:
         if name in self._accounts:
             raise CharacterAlreadyExistsError(f"Character '{name}' already exists.")
-        account = CharacterAccount(name, player=player, starting_gold=starting_gold)
+        account = CharacterAccount(
+            name,
+            player=player,
+            starting_gold=starting_gold,
+            sheet=sheet,
+        )
         self._accounts[name] = account
         return account
 
@@ -133,3 +139,99 @@ class DnDBank:
                 self._accounts[name].to_serialized() for name in self.list_characters()
             ]
         }
+
+    # Character sheet management -------------------------------------------------
+
+    def get_character_sheet(self, name: str) -> CharacterSheet:
+        return self.get_character(name).sheet
+
+    def update_character_sheet(self, name: str, **fields: object) -> CharacterSheet:
+        account = self.get_character(name)
+        return account.update_sheet(**fields)
+
+    def set_ability_scores(self, name: str, **scores: int) -> AbilityScores:
+        account = self.get_character(name)
+        return account.set_ability_scores(**scores)
+
+    def adjust_hit_points(
+        self,
+        name: str,
+        delta: int,
+        *,
+        use_temporary: bool = True,
+    ) -> HitPointPool:
+        account = self.get_character(name)
+        return account.adjust_hit_points(delta, use_temporary=use_temporary)
+
+    def set_hit_points(
+        self,
+        name: str,
+        *,
+        maximum: int | None = None,
+        current: int | None = None,
+        temporary: int | None = None,
+    ) -> HitPointPool:
+        account = self.get_character(name)
+        return account.set_hit_points(maximum=maximum, current=current, temporary=temporary)
+
+    # Inventory management -------------------------------------------------------
+
+    def list_inventory(self, name: str) -> Tuple[InventoryItem, ...]:
+        account = self.get_character(name)
+        return account.list_inventory()
+
+    def add_inventory_item(
+        self,
+        name: str,
+        *,
+        item_name: str,
+        quantity: int = 1,
+        description: str | None = None,
+        weight: float | None = None,
+        value_gp: AmountLike | None = None,
+        category: str | None = None,
+        equipped: bool | None = None,
+    ) -> InventoryItem:
+        account = self.get_character(name)
+        return account.add_inventory_item(
+            item_name,
+            quantity=quantity,
+            description=description,
+            weight=weight,
+            value_gp=value_gp,
+            category=category,
+            equipped=equipped,
+        )
+
+    def update_inventory_item(
+        self,
+        name: str,
+        item_name: str,
+        *,
+        quantity: int | None = None,
+        description: str | None = None,
+        weight: float | None = None,
+        value_gp: AmountLike | None = None,
+        category: str | None = None,
+        equipped: bool | None = None,
+    ) -> InventoryItem:
+        account = self.get_character(name)
+        return account.update_inventory_item(
+            item_name,
+            quantity=quantity,
+            description=description,
+            weight=weight,
+            value_gp=value_gp,
+            category=category,
+            equipped=equipped,
+        )
+
+    def remove_inventory_item(
+        self,
+        name: str,
+        item_name: str,
+        *,
+        quantity: int | None = None,
+    ) -> None:
+        account = self.get_character(name)
+        account.remove_inventory_item(item_name, quantity=quantity)

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -49,3 +49,64 @@ def test_transfer_between_accounts():
     assert target.balance == Decimal("5.00")
     assert outgoing.type is TransactionType.TRANSFER_OUT
     assert incoming.type is TransactionType.TRANSFER_IN
+
+
+def test_character_sheet_and_hit_points():
+    account = CharacterAccount("Rook")
+
+    sheet = account.update_sheet(
+        character_class="Wizard",
+        ancestry="Elf",
+        level=5,
+        experience=6500,
+        notes="Member of the Sapphire Cabal",
+    )
+    assert sheet.character_class == "Wizard"
+    assert sheet.level == 5
+    assert sheet.experience == 6500
+
+    abilities = account.set_ability_scores(strength=8, dexterity=16, intelligence=18)
+    assert abilities.dexterity == 16
+    assert abilities.modifier("intelligence") == 4
+
+    pool = account.set_hit_points(maximum=35, current=22, temporary=5)
+    assert pool.maximum == 35
+    assert pool.current == 22
+    assert pool.temporary == 5
+
+    new_pool = account.adjust_hit_points(-10)
+    assert new_pool.current == 17  # 5 temp absorbed, 5 damage applied
+
+
+def test_inventory_management():
+    account = CharacterAccount("Lyric")
+
+    potion = account.add_inventory_item(
+        "Healing Potion",
+        quantity=2,
+        description="Restores 2d4+2 HP",
+        value_gp="50",
+        category="Consumable",
+    )
+    assert potion.quantity == 2
+
+    stacked = account.add_inventory_item("Healing Potion", quantity=1)
+    assert stacked.quantity == 3
+
+    updated = account.update_inventory_item(
+        "Healing Potion",
+        quantity=5,
+        equipped=False,
+        description="Standard healing potion",
+    )
+    assert updated.quantity == 5
+    assert "Standard" in updated.description
+
+    account.remove_inventory_item("Healing Potion", quantity=2)
+    assert account.list_inventory()[0].quantity == 3
+
+    account.remove_inventory_item("Healing Potion")
+    assert account.list_inventory() == ()
+
+    with pytest.raises(KeyError):
+        account.remove_inventory_item("Unknown Item")

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -54,6 +54,15 @@ def test_serialization_round_trip():
     bank = DnDBank()
     bank.create_character("Dorian", starting_gold=2)
     bank.earn_gold("Dorian", 3, description="Contract")
+    bank.update_character_sheet(
+        "Dorian",
+        character_class="Sorcerer",
+        level=4,
+        notes="Silver-tongued diplomat",
+    )
+    bank.set_ability_scores("Dorian", charisma=18, wisdom=12)
+    bank.set_hit_points("Dorian", maximum=28, current=18, temporary=4)
+    bank.add_inventory_item("Dorian", item_name="Arcane Focus", category="Gear", equipped=True)
 
     payload = bank.to_serialized()
     restored = DnDBank.from_serialized(payload)
@@ -62,6 +71,9 @@ def test_serialization_round_trip():
     restored_account = restored.get_character("Dorian")
     assert restored_account.balance == bank.get_character("Dorian").balance
     assert len(restored_account.transactions) == len(bank.get_character("Dorian").transactions)
+    assert restored_account.sheet.character_class == "Sorcerer"
+    assert restored_account.sheet.hit_points.maximum == 28
+    assert restored_account.inventory[0].name == "Arcane Focus"
 
 
 def test_missing_character_raises_lookup_error():
@@ -69,3 +81,50 @@ def test_missing_character_raises_lookup_error():
 
     with pytest.raises(CharacterNotFoundError):
         bank.get_character("Unknown")
+
+
+def test_character_sheet_service_helpers():
+    bank = DnDBank()
+    bank.create_character("Kallias")
+
+    updated = bank.update_character_sheet(
+        "Kallias",
+        ancestry="Dragonborn",
+        character_class="Paladin",
+        level=6,
+    )
+    assert updated.level == 6
+
+    abilities = bank.set_ability_scores("Kallias", strength=18, charisma=14)
+    assert abilities.strength == 18
+
+    pool = bank.set_hit_points("Kallias", maximum=52, current=40)
+    assert pool.maximum == 52
+
+    after_damage = bank.adjust_hit_points("Kallias", -12)
+    assert after_damage.current == 28
+
+
+def test_inventory_service_flow():
+    bank = DnDBank()
+    bank.create_character("Seren")
+
+    item = bank.add_inventory_item(
+        "Seren",
+        item_name="Longsword",
+        quantity=1,
+        category="Weapon",
+        equipped=True,
+    )
+    assert item.equipped is True
+
+    updated = bank.update_inventory_item(
+        "Seren",
+        "Longsword",
+        description="Family heirloom",
+        quantity=1,
+    )
+    assert "heirloom" in updated.description
+
+    bank.remove_inventory_item("Seren", "Longsword")
+    assert bank.list_inventory("Seren") == ()


### PR DESCRIPTION
## Summary
- add dedicated dataclasses for character sheets, hit points, ability scores, and inventory items with full serialization support
- extend the CharacterAccount and DnDBank service layers plus the CLI to manage sheets, hit points, and equipment alongside gold tracking
- document the new commands and cover the features with unit tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d76f3915cc832eaca8b763490341cd